### PR TITLE
Fixed Top Aligned Label with multiple lines

### DIFF
--- a/Tableview Label/Base.lproj/Main.storyboard
+++ b/Tableview Label/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="sA9-R9-wgE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="sA9-R9-wgE">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--Test Table View Controller-->
@@ -18,7 +19,7 @@
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="tpJ-pM-dcc" id="IN0-55-cyV">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A8j-v4-OXR" customClass="TopAlignedLabel">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A8j-v4-OXR" customClass="TopAlignedLabel">
                                             <rect key="frame" x="21" y="33" width="280" height="49"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
@@ -31,6 +32,12 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailingMargin" secondItem="A8j-v4-OXR" secondAttribute="trailing" constant="11" id="5If-nu-L3N"/>
+                                        <constraint firstItem="A8j-v4-OXR" firstAttribute="top" secondItem="IN0-55-cyV" secondAttribute="topMargin" constant="25" id="JL2-JJ-B8Y"/>
+                                        <constraint firstItem="A8j-v4-OXR" firstAttribute="leading" secondItem="IN0-55-cyV" secondAttribute="leadingMargin" constant="13" id="XUc-p3-zEE"/>
+                                        <constraint firstItem="A8j-v4-OXR" firstAttribute="bottom" secondItem="IN0-55-cyV" secondAttribute="bottomMargin" id="jPu-8k-Bj8"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="mainLabel" destination="A8j-v4-OXR" id="2NM-HL-xZD"/>

--- a/Tableview Label/TestTableViewController.m
+++ b/Tableview Label/TestTableViewController.m
@@ -9,6 +9,8 @@
 #import "TestTableViewController.h"
 #import "TestTableViewCell.h"
 
+NSString * const TestSuperLongString = @"This text appears in TopAlignedLabel. While the text does top align, the ellipses occur when the text is too long.";
+
 @interface TestTableViewController ()
 
 @property (strong, nonatomic) NSArray *totalMessages;
@@ -17,37 +19,32 @@
 
 @implementation TestTableViewController
 
-- (void)viewDidLoad {
+- (void)viewDidLoad
+{
     [super viewDidLoad];
+    //generate random parts of our main string so that we can actually test the label
+    NSMutableArray *array = [NSMutableArray array];
+    for (int i = 0; i < 100; ++i) {
+        [array addObject:[TestSuperLongString substringToIndex:MAX(10,arc4random_uniform((uint32_t)TestSuperLongString.length))]];
+    }
+    self.totalMessages = [array copy];
+    self.tableView.rowHeight = 100;
     
-  
-}
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
 }
 
 #pragma mark - Table view data source
-
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-
-    // Return the number of sections.
-    return 1;
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    return self.totalMessages.count;
 }
-
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-
-    // Return the number of rows in the section.
-    return 1;
-}
-
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     TestTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell" forIndexPath:indexPath];
     
-    cell.mainLabel.text = @"This text appears in TopAlignedLabel. While the text does top align, the ellipses occur when the text is too long.";
+    cell.mainLabel.text = self.totalMessages[indexPath.row];
+    cell.mainLabel.layer.borderWidth = 1;
+    cell.mainLabel.layer.borderColor = [UIColor blackColor].CGColor;
     cell.subheadingLabel.text = @"This text appears in the regular UILabel.";
     
     cell.mainLabel.numberOfLines = 0;

--- a/Tableview Label/TopAlignedLabel.m
+++ b/Tableview Label/TopAlignedLabel.m
@@ -12,13 +12,11 @@
 
 - (void)drawTextInRect:(CGRect)rect {
     if (self.text) {
-        NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        paragraphStyle.lineBreakMode = self.lineBreakMode;
         CGSize labelStringSize = [self.text boundingRectWithSize:CGSizeMake(CGRectGetWidth(self.frame), CGFLOAT_MAX)
-                                                         options:NSStringDrawingUsesLineFragmentOrigin
-                                                      attributes:@{NSFontAttributeName:self.font,NSParagraphStyleAttributeName: paragraphStyle.copy}
+                                                         options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
+                                                      attributes:@{NSFontAttributeName:self.font}
                                                          context:nil].size;
-        [super drawTextInRect:CGRectMake(0, 0, CGRectGetWidth(self.frame),ceilf(labelStringSize.height))];
+        [super drawTextInRect:CGRectMake(0, 0, ceilf(CGRectGetWidth(self.frame)),ceilf(labelStringSize.height))];
     } else {
         [super drawTextInRect:rect];
     }


### PR DESCRIPTION
Check this out. Turns out we needed to turn off the paragraph style when calculating the string bounds